### PR TITLE
[feat] Oauth로그인/회원가입을 할 때 userInfo Filter 기능 추가

### DIFF
--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -24,9 +24,14 @@ ext {
 
 dependencies {
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
-	implementation 'org.springframework.cloud:spring-cloud-starter-gateway-mvc'
+	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 dependencyManagement {

--- a/gateway/src/main/kotlin/org/mungchi/backend/config/VendorConfiguration.kt
+++ b/gateway/src/main/kotlin/org/mungchi/backend/config/VendorConfiguration.kt
@@ -1,0 +1,16 @@
+package org.mungchi.backend.config
+
+import org.mungchi.backend.service.OauthClient
+import org.mungchi.backend.service.OauthClients
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+class VendorConfiguration {
+
+    @Bean
+    fun oauthClients(clients: Set<OauthClient>): OauthClients {
+        return OauthClients(clients)
+    }
+}

--- a/gateway/src/main/kotlin/org/mungchi/backend/filter/OauthFilter.kt
+++ b/gateway/src/main/kotlin/org/mungchi/backend/filter/OauthFilter.kt
@@ -1,0 +1,121 @@
+package org.mungchi.backend.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.mungchi.backend.suppert.JwtProvider
+import org.reactivestreams.Publisher
+import org.springframework.cloud.gateway.filter.GatewayFilter
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory
+import org.springframework.core.Ordered
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.core.io.buffer.DataBufferUtils
+import org.springframework.core.io.buffer.DefaultDataBufferFactory
+import org.springframework.http.ResponseCookie
+import org.springframework.http.server.reactive.ServerHttpRequestDecorator
+import org.springframework.http.server.reactive.ServerHttpResponseDecorator
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+
+@Component
+class OauthFilter(
+//    private val oauthService: OauthService,
+    private val jwtProvider: JwtProvider
+) : AbstractGatewayFilterFactory<OauthFilter.Config>(Config::class.java) ,Ordered {
+    private val objectMapper = ObjectMapper()
+
+
+    override fun apply(config: Config?): GatewayFilter {
+        return GatewayFilter { exchange, chain ->
+            val request = exchange.request
+            val response = exchange.response
+            val bodyFlux: Flux<DataBuffer> = request.body
+            val bodyMono: Mono<String> = DataBufferUtils.join(bodyFlux)
+                .flatMap { dataBuffer ->
+                    val byteArray = ByteArray(dataBuffer.readableByteCount())
+                    dataBuffer.read(byteArray)
+                    DataBufferUtils.release(dataBuffer)
+                    Mono.just(String(byteArray, Charsets.UTF_8))
+                }
+
+            bodyMono.flatMap { body ->
+                val jsonNode = objectMapper.readTree(body)
+                val socialType = jsonNode["socialType"].asText() ?: throw IllegalArgumentException()
+                val accessToken = jsonNode["accessToken"].asText() ?: throw IllegalArgumentException()
+//                val userInfo = oauthService.findUserInfo(SocialType.from(socialType), accessToken)
+
+//                val modifiedBody = objectMapper.writeValueAsString(userInfo.toMap())
+                val modifiedBody = objectMapper.writeValueAsString(
+                    mapOf(
+                        "socialId" to 1,
+                        "socialType" to "kako",
+                        "nickname" to "123"
+                    )
+                )
+
+                val modifiedRequest = object : ServerHttpRequestDecorator(request) {
+                    override fun getBody(): Flux<DataBuffer> {
+                        val bufferFactory = DefaultDataBufferFactory()
+                        val dataBuffer = bufferFactory.wrap(modifiedBody.toByteArray(StandardCharsets.UTF_8))
+                        return Flux.just(dataBuffer)
+                    }
+                }
+
+
+                chain.filter(exchange.mutate().request(modifiedRequest).build())
+                    .then(Mono.fromRunnable {
+                        // 수정된 Response Body를 처리하는 데코레이터 생성
+                        val decoratedResponse = object : ServerHttpResponseDecorator(response) {
+                            override fun writeWith(body: Publisher<out DataBuffer>): Mono<Void> {
+                                println("aaa        aaaaaaaaaaaaaaa")
+                                if (body is Flux) {
+                                    val fluxBody = body
+                                    return super.writeWith(fluxBody.map { dataBuffer ->
+                                        val content = ByteArray(dataBuffer.readableByteCount())
+                                        dataBuffer.read(content)
+
+                                        // 예: content를 문자열로 변환하여 로깅
+                                        val responseBody = String(content, StandardCharsets.UTF_8)
+
+                                        println(responseBody+"        aaaaaaaaaaaaaaa")
+                                        // 여기에서 response body의 값을 찾아서 로직을 수행하고 body를 수정
+                                        val userId = findUserIDFromResponseBody(responseBody)
+                                        val createToken = jwtProvider.createToken(userId)
+
+                                        // ResponseCookie 객체로 변경
+                                        val responseCookie = ResponseCookie.from("accessToken", createToken)
+                                            .maxAge(Duration.ofHours(12))
+                                            .build()
+                                        response.addCookie(responseCookie)
+                                        println("asdasdad")
+
+                                        // 최종적으로 body를 비우기
+                                        DefaultDataBufferFactory().wrap(ByteArray(0))
+                                    })
+                                }
+                                return super.writeWith(body)
+                            }
+                        }
+
+
+//                         chain.filter를 사용하여 불필요한 subscribe를 제거
+                        exchange.mutate().response(decoratedResponse).build()
+                    })
+            }
+        }
+    }
+
+
+    override fun getOrder(): Int {
+        return -2 // -1 is response write filter, must be called before that
+    }
+
+    private fun findUserIDFromResponseBody(responseBody: String): String {
+        val jsonNode = objectMapper.readTree(responseBody)
+        val userId = jsonNode["userID"] ?: throw IllegalArgumentException()
+        return userId.asText()
+    }
+
+    class Config
+}

--- a/gateway/src/main/kotlin/org/mungchi/backend/filter/OauthFilter2.kt
+++ b/gateway/src/main/kotlin/org/mungchi/backend/filter/OauthFilter2.kt
@@ -1,0 +1,77 @@
+package org.mungchi.backend.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.mungchi.backend.suppert.JwtProvider
+import org.reactivestreams.Publisher
+import org.springframework.cloud.gateway.filter.GatewayFilter
+import org.springframework.cloud.gateway.filter.NettyWriteResponseFilter
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory
+import org.springframework.core.Ordered
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.http.ResponseCookie
+import org.springframework.http.server.reactive.ServerHttpResponseDecorator
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+
+@Component
+class OauthFilter2(
+    private val jwtProvider: JwtProvider
+) : AbstractGatewayFilterFactory<OauthFilter2.Config>(Config::class.java), Ordered {
+    private val objectMapper = ObjectMapper()
+
+    override fun apply(config: Config?): GatewayFilter {
+        return GatewayFilter { exchange, chain ->
+            chain.filter(exchange).then(Mono.fromRunnable {
+                val response = exchange.response
+
+                // 수정된 Response Body를 처리하는 데코레이터 생성
+                val decoratedResponse = object : ServerHttpResponseDecorator(response) {
+                    override fun writeWith(body: Publisher<out DataBuffer>): Mono<Void> {
+                        if (body is Flux) {
+                            return super.writeWith(body.flatMap { dataBuffer ->
+                                val content = ByteArray(dataBuffer.readableByteCount())
+                                dataBuffer.read(content)
+                                val responseBody = String(content, StandardCharsets.UTF_8)
+
+                                // 여기에서 response body의 값을 찾아서 로직을 수행하고 body를 수정
+                                val userId = findUserIDFromResponseBody(responseBody)
+                                val createToken = jwtProvider.createToken(userId)
+
+                                // ResponseCookie 객체로 변경
+                                val responseCookie = ResponseCookie.from("accessToken", createToken)
+                                    .maxAge(Duration.ofHours(12))
+                                    .build()
+                                response.addCookie(responseCookie)
+
+                                // 최종적으로 body를 비우기
+                                Mono.just(dataBuffer)
+                            })
+                        }
+                        return super.writeWith(body)
+                    }
+                }
+
+                // chain.filter를 사용하여 불필요한 subscribe를 제거
+                exchange.mutate().response(decoratedResponse).build()
+            })
+        }
+    }
+
+    override fun getOrder(): Int {
+        return NettyWriteResponseFilter.WRITE_RESPONSE_FILTER_ORDER - 1;
+    }
+
+    private fun findUserIDFromResponseBody(responseBody: String): String {
+        return try {
+            val jsonNode = objectMapper.readTree(responseBody)
+            jsonNode["userID"]?.asText() ?: throw IllegalArgumentException("UserID not found")
+        } catch (e: Exception) {
+            throw RuntimeException("Failed to extract UserID from response body", e)
+        }
+    }
+
+    class Config
+}

--- a/gateway/src/main/kotlin/org/mungchi/backend/service/KakaoOauthClient.kt
+++ b/gateway/src/main/kotlin/org/mungchi/backend/service/KakaoOauthClient.kt
@@ -1,0 +1,27 @@
+package org.mungchi.backend.service
+
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+private const val PROFILE_URL = "https://kapi.kakao.com/v2/user/me"
+
+@Component
+class KakaoOauthClient(
+    private val webClient: WebClient = WebClient.create(PROFILE_URL)
+) : OauthClient {
+
+    override fun findUserInfo(accessToken: String): UserInfo {
+        return webClient.get()
+            .header("Authorization", "Bearer $accessToken")
+            .retrieve()
+            .onStatus({ it.is4xxClientError }) { Mono.error(IllegalArgumentException()) }
+            .onStatus({ it.is5xxServerError }) { Mono.error(IllegalArgumentException()) }
+            .bodyToMono(KakaoProfileResponse::class.java)
+            .block()?.toUserInfo() ?: throw IllegalArgumentException()
+    }
+
+    override fun getSocialType(): SocialType {
+        return SocialType.KAKAO
+    }
+}

--- a/gateway/src/main/kotlin/org/mungchi/backend/service/KakaoProfileResponse.kt
+++ b/gateway/src/main/kotlin/org/mungchi/backend/service/KakaoProfileResponse.kt
@@ -1,0 +1,21 @@
+package org.mungchi.backend.service
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class KakaoProfileResponse(
+    val id: Long,
+    @JsonProperty("kakao_account") val kakaoAccount: KakaoAccount
+) {
+    fun toUserInfo(): UserInfo {
+        val profile = kakaoAccount.profile
+        return UserInfo(
+            id,
+            SocialType.KAKAO,
+            profile.nickname
+        )
+    }
+
+    data class KakaoAccount(val profile: Profile) {
+        data class Profile(val nickname: String)
+    }
+}

--- a/gateway/src/main/kotlin/org/mungchi/backend/service/OauthClient.kt
+++ b/gateway/src/main/kotlin/org/mungchi/backend/service/OauthClient.kt
@@ -1,0 +1,7 @@
+package org.mungchi.backend.service
+
+interface OauthClient {
+    fun findUserInfo(accessToken :String) :UserInfo
+
+    fun  getSocialType(): SocialType
+}

--- a/gateway/src/main/kotlin/org/mungchi/backend/service/OauthClients.kt
+++ b/gateway/src/main/kotlin/org/mungchi/backend/service/OauthClients.kt
@@ -1,0 +1,21 @@
+package org.mungchi.backend.service
+
+import java.util.*
+
+class OauthClients(clients: Set<OauthClient>) {
+    private val mappingClients: Map<SocialType, OauthClient>
+
+    init {
+        val mapping = EnumMap<SocialType, OauthClient>(SocialType::class.java)
+        clients.forEach { client -> mapping[client.getSocialType()] = client }
+        this.mappingClients = mapping
+    }
+
+    fun findUserInfo(socialType: SocialType, accessToken: String): UserInfo {
+        val client: OauthClient = getClient(socialType)
+        return client.findUserInfo(accessToken)
+    }
+
+    private fun getClient(socialType: SocialType): OauthClient = mappingClients.get(socialType)
+        ?: throw IllegalArgumentException("해당 OAuth2 제공자는 지원되지 않습니다.")
+}

--- a/gateway/src/main/kotlin/org/mungchi/backend/service/OauthService.kt
+++ b/gateway/src/main/kotlin/org/mungchi/backend/service/OauthService.kt
@@ -1,0 +1,8 @@
+package org.mungchi.backend.service
+
+class OauthService(private val oauthClients: OauthClients) {
+
+    fun findUserInfo(socialType: SocialType, accessToken: String): UserInfo {
+        return oauthClients.findUserInfo(socialType, accessToken)
+    }
+}

--- a/gateway/src/main/kotlin/org/mungchi/backend/service/SocialType.kt
+++ b/gateway/src/main/kotlin/org/mungchi/backend/service/SocialType.kt
@@ -1,0 +1,15 @@
+package org.mungchi.backend.service
+
+enum class SocialType {
+    KAKAO;
+
+    companion object {
+        fun from(socialType: String): SocialType {
+            return when {
+                KAKAO.name.equals(socialType, ignoreCase = true) ->KAKAO
+                //TODO: 커스텀 에러로 변경
+                else -> throw IllegalArgumentException()
+            }
+        }
+    }
+}

--- a/gateway/src/main/kotlin/org/mungchi/backend/service/UserInfo.kt
+++ b/gateway/src/main/kotlin/org/mungchi/backend/service/UserInfo.kt
@@ -1,0 +1,7 @@
+package org.mungchi.backend.service
+
+data class UserInfo(
+    val socialId: Long,
+    val socialType: SocialType,
+    val nickname: String
+)

--- a/gateway/src/main/kotlin/org/mungchi/backend/suppert/JwtProvider.kt
+++ b/gateway/src/main/kotlin/org/mungchi/backend/suppert/JwtProvider.kt
@@ -1,0 +1,52 @@
+package org.mungchi.backend.suppert
+
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import org.springframework.stereotype.Component
+import java.util.*
+import javax.crypto.SecretKey
+
+private const val TWELVE_HOURS_IN_MILLISECONDS: Long = 1000 * 60 * 60 * 12
+
+@Component
+class JwtProvider(
+    private val signingKey: SecretKey = Keys.secretKeyFor(SignatureAlgorithm.HS256),
+    private val expirationInMilliseconds: Long = TWELVE_HOURS_IN_MILLISECONDS
+) {
+    fun createToken(payload: String): String {
+        val claims: Claims = Jwts.claims().setSubject(payload)
+        val now = Date()
+        val expiration = Date(now.time + expirationInMilliseconds)
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(expiration)
+            .signWith(signingKey)
+            .compact()
+    }
+
+    fun getSubject(token: String): String {
+        return getClaimsJws(token)
+            .body
+            .subject
+    }
+
+    fun isValidToken(token: String): Boolean {
+        return try {
+            getClaimsJws(token)
+            true
+        } catch (e: JwtException) {
+            false
+        } catch (e: IllegalArgumentException) {
+            false
+        }
+    }
+
+    private fun getClaimsJws(token: String) = Jwts.parserBuilder()
+        .setSigningKey(signingKey.encoded)
+        .build()
+        .parseClaimsJws(token)
+}

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 8081
 
 eureka:
   client:
@@ -15,7 +15,16 @@ spring:
     gateway:
       mvc:
         routes:
-          - id: user-service
+          - id: USER-SERVICE
             uri: lb://USER-SERVICE
             predicates:
-              - Path=/user-service/**
+              - Path=/user-service/login
+            filters:
+              - name: OauthFilter
+          - id: USER-SERVICE
+            uri: lb://USER-SERVICE
+            predicates:
+              - Path=/user-service/test
+            filters:
+              - name: OauthFilter2
+


### PR DESCRIPTION
### 관련 이슈
- #4 

### 설명

- oauth 서버를 통해 회원 정보를 가져온후 request body에 적제하는 filter추가
- user server에서 로그인/회원가입을 진행 후 gateway 서버에서 response에 body에 담긴 userID를 읽고 jwt를 생성 후 cookie에 적제
